### PR TITLE
feat: remove unused "Contact Us" link from Header component

### DIFF
--- a/client/src/components/Navbar/Header.jsx
+++ b/client/src/components/Navbar/Header.jsx
@@ -39,7 +39,6 @@ const Header = () => {
           <Link to="/families" className="nav-link underline-transition">Families</Link>
           <Link to="/departments" className="nav-link underline-transition">Departments</Link>
           <Link to="/church-gallery" className="nav-link underline-transition">Gallery</Link>
-          <Link to="#" className="nav-link underline-transition">Contact Us</Link>
         </div>
 
         {/* Auth Buttons and Donate on the Right */}


### PR DESCRIPTION
This pull request includes a small change to the `client/src/components/Navbar/Header.jsx` file. The change removes the "Contact Us" link from the navigation bar.

* [`client/src/components/Navbar/Header.jsx`](diffhunk://#diff-8a38ed69ec50ee570fcb0c067b660fc419d09fa112f35960de08624a9a7fe150L42): Removed the "Contact Us" link from the navigation bar.