### PR TITLE
Dev

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -31,7 +31,7 @@ app.use(cookieParser());
 const allowedOrigins = [
   "http://localhost:5173",
   "http://localhost:3000",
-  "https://church-system-three.vercel.app/",
+  "https://church-system-three.vercel.app",
 ];
 
 app.use(

--- a/server/app.ts
+++ b/server/app.ts
@@ -31,7 +31,7 @@ app.use(cookieParser());
 const allowedOrigins = [
   "http://localhost:5173",
   "http://localhost:3000",
-  "https://jolly-coast-0386d1803.5.azurestaticapps.net",
+  "https://church-system-three.vercel.app/",
 ];
 
 app.use(


### PR DESCRIPTION
This pull request updates the list of allowed origins in the CORS configuration for the server. The change replaces an outdated Azure static app URL with a new Vercel deployment URL.

* [`server/app.ts`](diffhunk://#diff-226c1869e16c3e24e492b3483e64e2c58cca766e43b81632c01fb056ff8f666dL34-R34): Updated the list of allowed origins in the CORS configuration by replacing `https://jolly-coast-0386d1803.5.azurestaticapps.net` with `https://church-system-three.vercel.app/`.